### PR TITLE
removed back .vscode from .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,4 @@
 *.out
 *.app
 build/
-**/.vscode/
 .DS_Store


### PR DESCRIPTION
As per this Vex thread (https://www.vexforum.com/t/vex-vscode-extension-does-not-recognized-a-project-created-thorugh-the-vscode-extention/121117/1), it turned out that the VEX vscode stores the project information in vex_project_settings.json file inside .vscode. Without this file, the VEX vscode extension can't recognize the vex project.

Therefore, removed the original .vscode from the .gitinore file. FYI: .gitignore file is to list files that should be committed into the gitHub for sharing.